### PR TITLE
18 add file size bucket

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,11 @@ and reporting which directories consume what space.`,
 			(paths),
 			viper.GetBool("follow-symlinks"),
 		)
-		e.SetDirOnly(viper.GetBool("dir-only"))
+		e.SetCollectionFlags(
+			viper.GetBool("dir-count"),
+			viper.GetBool("file-count"),
+			viper.GetBool("size-bucket"),
+		)
 		e.SetIgnoreDirPaths(viper.GetStringSlice("ignore-dirs"))
 
 		if viper.IsSet("basic-auth-users") {
@@ -114,7 +118,9 @@ func init() {
 		"follow-symlinks", "L", false,
 		"Follow symlinks for files, i.e. show the size of the file to which symlink points to (symlinks to directories are not followed)",
 	)
-	flags.Bool("dir-only", false, "Only analyze directories, exclude individual files from metrics")
+	flags.Bool("dir-count", true, "Collect directory count metrics")
+	flags.Bool("file-count", true, "Collect file count metrics")
+	flags.Bool("size-bucket", true, "Collect size bucket metrics")
 	flags.StringToString("multi-paths", map[string]string{}, "Multiple paths where to analyze disk usage, in format /path1=level1,/path2=level2,...")
 	flags.StringToString("basic-auth-users", map[string]string{}, "Basic Auth users and their passwords as bcypt hashes")
 	flags.StringP("storage-path", "s", "", "Path to store cached analysis data")

--- a/config-basic.yml
+++ b/config-basic.yml
@@ -16,9 +16,14 @@ log-level: "debug"
 # Maximum number of CPU cores to use for parallel processing
 max-procs: 4
 
-# Directory-only mode configuration
-# Only analyze directories, exclude individual files from metrics
-dir-only: true
+# Whether to collect node_disk_usage_directory_count
+dir-count: true
+
+# Whether to collect node_disk_usage_file_count
+file-count: true
+
+# Whether to collect node_disk_usage_size_bucket
+size-bucket: true
 
 # Directories to ignore during analysis
 ignore-dirs:

--- a/config-caching.yml
+++ b/config-caching.yml
@@ -3,9 +3,10 @@
 
 # Basic configuration
 # analyzed-path: "/mnt/meta-test"
-analyzed-path: "/home"
+# analyzed-path: "/home/kklee228"
+analyzed-path: "/srv/nfs/shared/meta-test"
 bind-address: "0.0.0.0:9996"
-dir-level: 4
+dir-level: 3
 mode: "http"
 follow-symlinks: false
 
@@ -17,9 +18,14 @@ log-level: "debug"
 # Maximum number of CPU cores to use for parallel processing
 max-procs: 12
 
-# Directory-only mode configuration
-# Only analyze directories, exclude individual files from metrics
-dir-only: true
+# Whether to collect node_disk_usage_directory_count
+dir-count: true
+
+# Whether to collect node_disk_usage_file_count
+file-count: true
+
+# Whether to collect node_disk_usage_size_bucket
+size-bucket: true
 
 # Background caching configuration
 # Both storage-path and scan-interval-minutes must be set to enable caching

--- a/config-multipaths.yml
+++ b/config-multipaths.yml
@@ -22,9 +22,14 @@ multi-paths:
   /tmp: 1
   /opt: 2
 
-# Directory-only mode configuration
-# Only analyze directories, exclude individual files from metrics
-dir-only: true
+# Whether to collect node_disk_usage_directory_count
+dir-count: true
+
+# Whether to collect node_disk_usage_file_count
+file-count: true
+
+# Whether to collect node_disk_usage_size_bucket
+size-bucket: true
 
 # Background caching configuration (optional)
 storage-path: "/tmp/disk-usage-cache"

--- a/config.yml
+++ b/config.yml
@@ -16,9 +16,14 @@ log-level: "debug"
 # Maximum number of CPU cores to use for parallel processing
 max-procs: 4
 
-# Directory-only mode configuration
-# Only analyze directories, exclude individual files from metrics
-dir-only: true
+# Whether to collect node_disk_usage_directory_count
+dir-count: true
+
+# Whether to collect node_disk_usage_file_count
+file-count: true
+
+# Whether to collect node_disk_usage_size_bucket
+size-bucket: true
 
 # Background caching configuration (optional)
 # Both storage-path and scan-interval-minutes must be set to enable caching

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"runtime"
 	"runtime/debug"
 	"sync"
@@ -20,13 +21,6 @@ import (
 
 var (
 	// 계층적 집계 메트릭
-	diskUsageDirectory = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "node_disk_usage_directory_bytes",
-			Help: "Total disk usage by directory",
-		},
-		[]string{"path", "level"},
-	)
 	diskUsageFileCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "node_disk_usage_file_count",
@@ -42,13 +36,13 @@ var (
 		[]string{"path", "level"},
 	)
 	
-	// 타입별 집계 메트릭
-	diskUsageByType = prometheus.NewGaugeVec(
+	// 디스크 사용량 메트릭
+	diskUsage = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "node_disk_usage_by_type_bytes",
-			Help: "Disk usage aggregated by file type",
+			Name: "node_disk_usage",
+			Help: "Total disk usage by directory",
 		},
-		[]string{"path", "type", "level"},
+		[]string{"path", "level"},
 	)
 	
 	// 크기별 버킷 메트릭
@@ -84,8 +78,8 @@ var (
 	)
 	
 	collectors = []prometheus.Collector{
-		diskUsageDirectory, diskUsageFileCount, diskUsageDirectoryCount,
-		diskUsageByType, diskUsageSizeBucket, diskUsageTopFiles,
+		diskUsageFileCount, diskUsageDirectoryCount,
+		diskUsage, diskUsageSizeBucket, diskUsageTopFiles,
 		diskUsageOthersTotal, diskUsageOthersCount,
 	}
 )
@@ -102,11 +96,9 @@ type aggregatedStats struct {
 	sync.Mutex
 	path           string
 	level          int
-	totalSize      int64
+	totalSize      int64             // total size for by_type metric
 	fileCount      int64
 	directoryCount int64
-	fileSize       int64
-	directorySize  int64
 	sizeBuckets    map[string]int64  // size_range -> count
 	topFiles       []topFileInfo     // largest files
 	othersTotal    int64
@@ -183,7 +175,9 @@ type Exporter struct {
 	stopChan       chan struct{}
 	useStorage     bool
 	maxProcs       int
-	dirOnly        bool
+	collectDirCount    bool
+	collectFileCount   bool
+	collectSizeBucket  bool
 	
 	// Sequential DB write components
 	sharedStorage  *analyze.Storage
@@ -240,9 +234,11 @@ func (e *Exporter) SetMaxProcs(maxProcs int) {
 	e.maxProcs = maxProcs
 }
 
-// SetDirOnly sets whether to analyze only directories or include files
-func (e *Exporter) SetDirOnly(dirOnly bool) {
-	e.dirOnly = dirOnly
+// SetCollectionFlags sets which metrics to collect
+func (e *Exporter) SetCollectionFlags(dirCount, fileCount, sizeBucket bool) {
+	e.collectDirCount = dirCount
+	e.collectFileCount = fileCount
+	e.collectSizeBucket = sizeBucket
 }
 
 // initializeSharedStorage initializes shared storage and starts writer goroutine
@@ -505,14 +501,13 @@ func (e *Exporter) provideEmptyMetrics() {
 	for path, level := range e.paths {
 		for i := 0; i <= level; i++ {
 			levelStr := fmt.Sprintf("%d", i)
-			diskUsageDirectory.WithLabelValues(path, levelStr).Set(0)
-			diskUsageDirectoryCount.WithLabelValues(path, levelStr).Set(0)
-			diskUsageByType.WithLabelValues(path, "directory", levelStr).Set(0)
 			
-			// Only provide file-related metrics if dir-only is disabled
-			if !e.dirOnly {
+			// Provide metrics based on collection flags
+			if e.collectDirCount {
+				diskUsageDirectoryCount.WithLabelValues(path, levelStr).Set(0)
+			}
+			if e.collectFileCount {
 				diskUsageFileCount.WithLabelValues(path, levelStr).Set(0)
-				diskUsageByType.WithLabelValues(path, "file", levelStr).Set(0)
 			}
 		}
 	}
@@ -533,9 +528,10 @@ func (e *Exporter) performLiveAnalysisWithStored(stored *analyze.StoredAnalyzer)
 					// Set zero values for metrics when analysis fails
 					for i := 0; i <= level; i++ {
 						levelStr := fmt.Sprintf("%d", i)
-						diskUsageDirectory.WithLabelValues(path, levelStr).Set(0)
-						diskUsageDirectoryCount.WithLabelValues(path, levelStr).Set(0)
-						if !e.dirOnly {
+						if e.collectDirCount {
+							diskUsageDirectoryCount.WithLabelValues(path, levelStr).Set(0)
+						}
+						if e.collectFileCount {
 							diskUsageFileCount.WithLabelValues(path, levelStr).Set(0)
 						}
 					}
@@ -607,9 +603,10 @@ func (e *Exporter) loadFromStorage() {
 		for path, level := range e.paths {
 			for i := 0; i <= level; i++ {
 				levelStr := fmt.Sprintf("%d", i)
-				diskUsageDirectory.WithLabelValues(path, levelStr).Set(0)
-				diskUsageDirectoryCount.WithLabelValues(path, levelStr).Set(0)
-				if !e.dirOnly {
+				if e.collectDirCount {
+					diskUsageDirectoryCount.WithLabelValues(path, levelStr).Set(0)
+				}
+				if e.collectFileCount {
 					diskUsageFileCount.WithLabelValues(path, levelStr).Set(0)
 				}
 			}
@@ -625,9 +622,10 @@ func (e *Exporter) loadFromStorage() {
 			// Return empty metrics (0 bytes) for missing cache data
 			for i := 0; i <= level; i++ {
 				levelStr := fmt.Sprintf("%d", i)
-				diskUsageDirectory.WithLabelValues(path, levelStr).Set(0)
-				diskUsageDirectoryCount.WithLabelValues(path, levelStr).Set(0)
-				if !e.dirOnly {
+				if e.collectDirCount {
+					diskUsageDirectoryCount.WithLabelValues(path, levelStr).Set(0)
+				}
+				if e.collectFileCount {
 					diskUsageFileCount.WithLabelValues(path, levelStr).Set(0)
 				}
 			}
@@ -665,18 +663,25 @@ func (e *Exporter) collectAggregatedStats(item fs.Item, level, maxLevel int, roo
 
 	path := item.GetPath()
 	
-	// Skip files entirely if dir-only mode is enabled
-	if e.dirOnly && !item.IsDir() {
+	// Skip files if no file-related metrics are needed
+	if !item.IsDir() && !e.collectFileCount && !e.collectSizeBucket {
 		return
 	}
 	
+	// For files, use parent directory path for aggregation
+	aggregationPath := path
+	if !item.IsDir() {
+		// Get parent directory path for file aggregation
+		aggregationPath = filepath.Dir(path)
+	}
+	
 	// Initialize aggregated stats for this path/level if it doesn't exist
-	key := fmt.Sprintf("%s:%d", path, level)
+	key := fmt.Sprintf("%s:%d", aggregationPath, level)
 	
 	e.tempStatsMutex.Lock()
 	if e.tempStats[key] == nil {
 		e.tempStats[key] = &aggregatedStats{
-			path:        path,
+			path:        aggregationPath,
 			level:       level,
 			sizeBuckets: make(map[string]int64),
 			topFiles:    make([]topFileInfo, 0),
@@ -691,15 +696,19 @@ func (e *Exporter) collectAggregatedStats(item fs.Item, level, maxLevel int, roo
 		stats.totalSize += item.GetUsage()
 		
 		if item.IsDir() {
-			stats.directoryCount++
-			stats.directorySize += item.GetUsage()
-		} else if !e.dirOnly {
-			// Only process files if dir-only mode is disabled
-			// Only collect size bucket data, skip file count, file size, and top files
+			if e.collectDirCount {
+				stats.directoryCount++
+			}
+		} else {
+			// Process file metrics based on collection flags
+			if e.collectFileCount {
+				stats.fileCount++
+			}
 			
-			// Update size buckets
-			sizeRange := getSizeRange(item.GetUsage())
-			stats.sizeBuckets[sizeRange]++
+			if e.collectSizeBucket {
+				sizeRange := getSizeRange(item.GetUsage())
+				stats.sizeBuckets[sizeRange]++
+			}
 		}
 		stats.Unlock()
 	}
@@ -772,20 +781,25 @@ func (e *Exporter) publishAggregatedMetrics() {
 		stats.Lock()
 		levelStr := fmt.Sprintf("%d", stats.level)
 		
-		// Directory-level metrics
-		diskUsageDirectory.WithLabelValues(stats.path, levelStr).Set(float64(stats.totalSize))
-		diskUsageDirectoryCount.WithLabelValues(stats.path, levelStr).Set(float64(stats.directoryCount))
+		// Always publish total disk usage metric
+		diskUsage.WithLabelValues(stats.path, levelStr).Set(float64(stats.totalSize))
 		
-		// Size bucket metrics (always published, even in dir-only mode)
-		for sizeRange, count := range stats.sizeBuckets {
-			diskUsageSizeBucket.WithLabelValues(stats.path, sizeRange, levelStr).Set(float64(count))
+		// Publish metrics based on collection flags
+		if e.collectDirCount {
+			diskUsageDirectoryCount.WithLabelValues(stats.path, levelStr).Set(float64(stats.directoryCount))
 		}
 		
-		// File-related metrics are not published when dir-only is false
-		// Only size bucket metrics are collected and published
+		if e.collectFileCount {
+			diskUsageFileCount.WithLabelValues(stats.path, levelStr).Set(float64(stats.fileCount))
+		}
 		
-		// Directory type-based metrics (always published)
-		diskUsageByType.WithLabelValues(stats.path, "directory", levelStr).Set(float64(stats.directorySize))
+		if e.collectSizeBucket {
+			for sizeRange, count := range stats.sizeBuckets {
+				diskUsageSizeBucket.WithLabelValues(stats.path, sizeRange, levelStr).Set(float64(count))
+			}
+		}
+		
+		// Total disk usage metric is published above
 		
 		stats.Unlock()
 	}


### PR DESCRIPTION
# 메트릭 수집 기능 제어 세분화.

## 🎯 주요 변경사항

### 세분화된 메트릭 수집 옵션 추가
- `dir-only` 설정 제거, 개별 메트릭 타입별 제어 가능
- `dir-count`: 디렉토리 개수 메트릭 수집 여부 (기본: true)
- `file-count`: 파일 개수 메트릭 수집 여부 (기본: true)  
- `size-bucket`: 크기별 버킷 메트릭 수집 여부 (기본: true)

### 메트릭 구조 개선
- `node_disk_usage_by_type_bytes` → `node_disk_usage`로 이름 변경
- `type="file"`, `type="directory"` 레이블 제거
- `node_disk_usage_directory_bytes` 메트릭 제거 (node_disk_usage로 통합)

## ⚡ 개선 효과
- **리소스 효율성**: 필요한 메트릭만 선택적 수집
- **설정 유연성**: 사용 사례별 맞춤 설정 가능
- **메트릭 단순화**: 직관적인 메트릭 이름과 구조

## 📝 설정 예시
```yaml
# 세분화된 메트릭 수집 설정
dir-count: true      # 디렉토리 개수
file-count: true     # 파일 개수  
size-bucket: true    # 크기별 분포
```

## 🔄 마이그레이션
- `dir-only: false` → `dir-count: true, file-count: true, size-bucket: true`
- Prometheus 쿼리: `node_disk_usage_directory_bytes` → `node_disk_usage`